### PR TITLE
Added automatic html id to headings

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -332,6 +332,23 @@ function autonomie_content_width() {
 add_action( 'after_setup_theme', 'autonomie_content_width', 0 );
 
 /**
+ * Automatically add IDs to headings such as <h2></h2>
+ */
+function auto_id_headings( $content ) {
+
+	$content = preg_replace_callback( '/(\<h[1-6](.*?))\>(.*)(<\/h[1-6]>)/i', function( $matches ) {
+		if ( ! stripos( $matches[0], 'id=' ) ) :
+			$matches[0] = $matches[1] . $matches[2] . ' id="' . sanitize_title( $matches[3] ) . '">' . $matches[3] . $matches[4];
+		endif;
+		return $matches[0];
+	}, $content );
+
+    return $content;
+
+}
+add_filter( 'the_content', 'auto_id_headings' );
+
+/**
  * Set the default maxwith for the embeds
  */
 function autonomie_embed_defaults() {


### PR DESCRIPTION
This will add HTML ids to headings (like h1/h2/...). If the heading already has an id, the code will do nothing.