### PR TITLE
Switch to get_template_directory_uri for enqueue

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -402,10 +402,10 @@ if ( ! function_exists( 'autonomie_enqueue_scripts' ) ) :
 
 		// Loads our main stylesheet.
 		wp_enqueue_style( 'autonomie-style', get_stylesheet_uri(), array( 'dashicons' ) );
-		wp_enqueue_style( 'autonomie-print-style', get_stylesheet_directory_uri() . '/assets/css/print.css', array( 'autonomie-style' ), '1.0.0', 'print' );
-		wp_enqueue_style( 'autonomie-narrow-style', get_stylesheet_directory_uri() . '/assets/css/narrow-width.css', array( 'autonomie-style' ), '1.0.0', '(max-width: 800px)' );
-		wp_enqueue_style( 'autonomie-default-style', get_stylesheet_directory_uri() . '/assets/css/default-width.css', array( 'autonomie-style' ), '1.0.0', '(min-width: 800px)' );
-		wp_enqueue_style( 'autonomie-wide-style', get_stylesheet_directory_uri() . '/assets/css/wide-width.css', array( 'autonomie-style' ), '1.0.0', '(min-width: 1000px)' );
+		wp_enqueue_style( 'autonomie-print-style', get_template_directory_uri() . '/assets/css/print.css', array( 'autonomie-style' ), '1.0.0', 'print' );
+		wp_enqueue_style( 'autonomie-narrow-style', get_template_directory_uri() . '/assets/css/narrow-width.css', array( 'autonomie-style' ), '1.0.0', '(max-width: 800px)' );
+		wp_enqueue_style( 'autonomie-default-style', get_template_directory_uri() . '/assets/css/default-width.css', array( 'autonomie-style' ), '1.0.0', '(min-width: 800px)' );
+		wp_enqueue_style( 'autonomie-wide-style', get_template_directory_uri() . '/assets/css/wide-width.css', array( 'autonomie-style' ), '1.0.0', '(min-width: 1000px)' );
 
 		wp_localize_script(
 			'autonomie',


### PR DESCRIPTION
Using `get_stylesheet_directory_uri()`can cause issues for child themes, as WordPress tries to enqueue a file in the currently active theme directory instead of the root theme's directory. 

`get_template_directory_uri()` returns the root theme URI, so the child theme doesn't have to handle assets like `print.css`, `narrow-width.css`, `default-width.css`, and `wide-width.css`.